### PR TITLE
feat(maestro): add turbo submit

### DIFF
--- a/packages/whisky-provider/src/maestro/fetcher.rs
+++ b/packages/whisky-provider/src/maestro/fetcher.rs
@@ -76,7 +76,6 @@ impl Fetcher for MaestroProvider {
             .map(to_utxo)
             .collect::<Result<Vec<_>, _>>()
             .map_err(WError::from_err("maestro::fetch_address_utxos to_utxo"))?;
-        println!("uxtos: {:?}", added_utxos);
 
         while utxos_at_address.next_cursor.is_some() {
             let append_cursor_string = format!(

--- a/packages/whisky-provider/src/maestro/mod.rs
+++ b/packages/whisky-provider/src/maestro/mod.rs
@@ -13,11 +13,16 @@ use serde::Serialize;
 pub struct Maestro {
     api_key: String,
     http_client: reqwest::Client,
+    turbo_submit: bool,
     pub base_url: String,
 }
 
 impl Maestro {
     pub fn new(api_key: String, network: String) -> Self {
+        Self::new_with_turbo_submit(api_key, network, false)
+    }
+
+    pub fn new_with_turbo_submit(api_key: String, network: String, turbo_submit: bool) -> Self {
         let base_url = format!("https://{}.gomaestro-api.org/v1", &network,);
         let http_client = reqwest::Client::builder()
             .timeout(std::time::Duration::from_secs(300))
@@ -28,6 +33,7 @@ impl Maestro {
             api_key,
             http_client,
             base_url,
+            turbo_submit,
         }
     }
 
@@ -42,8 +48,6 @@ impl Maestro {
             .build()?;
 
         let response = self.http_client.execute(req).await?;
-
-        println!("response: {:?}", response);
 
         if response.status().is_success() {
             *response_body = response.text().await?;
@@ -89,5 +93,14 @@ impl MaestroProvider {
     pub fn new(api_key: &str, network: &str) -> MaestroProvider {
         let maestro_client = Maestro::new(api_key.to_string(), network.to_string());
         MaestroProvider { maestro_client }
+    }
+
+    pub fn new_with_turbo_submit(api_key: &str, network: &str) -> MaestroProvider {
+        Self::new(api_key, network).with_turbo_submit(true)
+    }
+
+    pub fn with_turbo_submit(mut self, turbo_submit: bool) -> MaestroProvider {
+        self.maestro_client.turbo_submit = turbo_submit;
+        self
     }
 }

--- a/packages/whisky-provider/src/maestro/submitter.rs
+++ b/packages/whisky-provider/src/maestro/submitter.rs
@@ -6,7 +6,11 @@ use super::MaestroProvider;
 #[async_trait]
 impl Submitter for MaestroProvider {
     async fn submit_tx(&self, tx_hex: &str) -> Result<String, WError> {
-        let url = "/txmanager";
+        let url = if self.maestro_client.turbo_submit {
+            "/txmanager/turbosubmit"
+        } else {
+            "/txmanager"
+        };
         let maestro_client = &self.maestro_client;
 
         let tx_binary = hex::decode(tx_hex).map_err(WError::from_err("Invalid hex data"))?;


### PR DESCRIPTION
## Summary

  Adds optional Maestro Turbo Submit support in whisky-provider. Maestro transactions can now be submitted
  through /txmanager/turbosubmit for priority processing, while the existing /txmanager submit path
  remains the default and backward compatible.

  Also removes debug logging from Maestro provider code.

  ## Scope of Change

  - [ ] whisky
  - [X] whisky-provider
  - [ ] whisky-wallet
  - [ ] whisky-csl
  - [ ] whisky-common
  - [ ] whisky-macros
  - [ ] whisky-js

  ## Type of Change

  ### Feature Change

  1. New feature - non-breaking change which adds functionality

  ### Maintenance

  - [ ] Bug fix (non-breaking change which fixes an issue)
  - [X] Code refactoring (improving code quality without changing its behavior)
  - [ ] Documentation update (adding or updating documentation related to the project)

  ## Checklist

  - [X] My code is appropriately commented and includes relevant documentation, if necessary
  - [ ] I have added tests to cover my changes, if necessary
  - [ ] I have updated the documentation, if necessary
  - [X] All new and existing tests pass
  - [ ] Both rust and wasm build pass

  ## Additional Information