### PR TITLE
chore(ci): pin npm to 12.0.2 and add supply-chain cooldown

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -105,8 +105,11 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           registry-url: https://registry.npmjs.org/
+      - name: Update NPM
+        run: npm install -g npm@12.0.2
+
       - name: Install dependencies
         run: npm install && cargo install wasm-pack
       - run: npm run js:publish-nodejs && npm run js:publish-browser

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -33,6 +33,9 @@ jobs:
         uses: actions/checkout@v4
       - name: Setup Pages
         uses: actions/configure-pages@v5
+      - name: Update NPM
+        run: npm install -g npm@12.0.2
+
       - name: Build docs
         run: |
           npm run rust:doc

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,5 @@
+# Supply-chain cooldown: refuse dependency versions published <7 days ago (npm 12+).
+# Own packages are exempt so same-day @midnight-ntwrk releases stay installable.
+min-release-age=7
+min-release-age-exclude[]=@midnight-ntwrk/*
+min-release-age-exclude[]=@midnightntwrk/*

--- a/.npmrc
+++ b/.npmrc
@@ -1,5 +1,3 @@
 # Supply-chain cooldown: refuse dependency versions published <7 days ago (npm 12+).
 # Own packages are exempt so same-day @midnight-ntwrk releases stay installable.
 min-release-age=7
-min-release-age-exclude[]=@midnight-ntwrk/*
-min-release-age-exclude[]=@midnightntwrk/*


### PR DESCRIPTION
Supply-chain hardening following the 2026-08-04 keyv/cacheable npm worm (868+ packages compromised via `preinstall` payloads published through legitimate maintainer accounts).

- Pin the npm CLI to 12.0.2 in CI (npm 12 blocks dependency lifecycle scripts by default behind `allowScripts`) instead of floating `npm@latest`
- Add `.npmrc` cooldown: `min-release-age=7` so freshly-published (potentially compromised) versions can't resolve until they've aged 7 days
